### PR TITLE
WDL for creating cellranger reference, cellranger atac reference, and smartseq2 reference

### DIFF
--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -50,7 +50,7 @@ task run_cellranger_atac_create_reference {
 	}
 
 	output {
-		File reference = "#{output_dir}/${genome}.tar.gz"
+		File reference = "${output_dir}/${genome}.tar.gz"
 	}
 
 	runtime {

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -10,7 +10,7 @@ workflow cellranger_atac_create_reference {
 	String output_dir
 	String genome
 
-	call run_cellranger_atac_create_reference as atac_mkref {
+	call run_cellranger_atac_create_reference {
 		input:
 			docker_registry = docker_registry,
 			cellranger_atac_version = cellranger_atac_version,
@@ -39,17 +39,16 @@ task run_cellranger_atac_create_reference {
 
 	command {
 		set -e
-		monitor_script.sh > monitoring.log
 
 		cellranger-atac mkref ${genome} --config ${config_json}
 		tar -czf ${genome}.tar.gz ${genome}
-		# gsutil -q cp ${genome}.tar.gz ${output_dir}
-		mkdir -p ${output_dir}
-		cp ${genome}.tar.gz ${output_dir}
+		gsutil -q cp ${genome}.tar.gz ${output_dir}
+		# mkdir -p ${output_dir}
+		# cp ${genome}.tar.gz ${output_dir}
 	}
 
 	output {
-		File reference = "${genome}.tar.gz"
+		File reference = "#{output_dir}/${genome}.tar.gz"
 	}
 
 	runtime {

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -1,6 +1,6 @@
 workflow cellranger_atac_create_reference {
 	String? docker_registry = "cumulusprod/"
-	String? cellranger_atac_version = '1.1.0'
+	String? cellranger_atac_version = '1.0.0'
 	Int? disk_space = 500
 	Int? preemptible = 2
 	String? zones = "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c"

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -39,14 +39,13 @@ task run_cellranger_atac_create_reference {
 
 	command {
 		set -e
-		export TMPDIR=/tmp
 		monitor_script.sh > monitoring.log
 
 		cellranger-atac mkref ${genome} --config ${config_json}
-
-		# gsutil -q cp -r ${genome} ${output_dir}/${genome}
+		tar -czf ${genome}.tar.gz ${genome}
+		# gsutil -q cp ${genome}.tar.gz ${output_dir}
 		mkdir -p ${output_dir}
-		cp -r ${genome} ${output_dir}/
+		cp ${genome}.tar.gz ${output_dir}
 	}
 
 	output {
@@ -57,7 +56,6 @@ task run_cellranger_atac_create_reference {
 		docker: "${docker_registry}cellranger-atac:${cellranger_atac_version}"
 		zones: zones
 		memory: memory
-		bootDiskSizeGb: 12
 		disks: "local-disk ${disk_space} HDD"
 		cpu: 1
 		preemptible: "${preemptible}"

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -1,6 +1,6 @@
 workflow cellranger_atac_create_reference {
 	String? docker_registry = "cumulusprod/"
-	String? cellranger_atac_version = '1.0.0'
+	String? cellranger_atac_version = '1.1.0'
 	Int? disk_space = 500
 	Int? preemptible = 2
 	String? zones = "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c"

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -39,6 +39,8 @@ task run_cellranger_atac_create_reference {
 
 	command {
 		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log &
 
 		cellranger-atac mkref ${genome} --config ${config_json}
 		tar -czf ${genome}.tar.gz ${genome}

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -1,0 +1,75 @@
+workflow cellranger_atac_create_reference {
+	String? docker_registry = "cumulusprod/"
+	String? cellranger_atac_version = '1.1.0'
+	Int? disk_space = 500
+	Int? preemptible = 2
+	String? zones = "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c"
+	String? memory = "32G"
+
+	File config_json
+	String output_dir
+	String genome
+
+	Boolean do_filter = if '${attributes}' != '' then true else false
+
+	call run_cellranger_atac_create_reference as atac_mkref {
+		input:
+			docker_registry = docker_registry,
+			cellranger_atac_version = cellranger_atac_version,
+			disk_space = disk_space,
+			preemptible = preemptible,
+			zones = zones,
+			memory = memory,
+			config_json = config_json,
+			output_dir = output_dir,
+			genome = genome
+	}
+
+}
+
+task run_cellranger_atac_create_reference {
+	String docker_registry
+	String cellranger_atac_version
+	Int disk_space
+	String zones
+	String memory
+	Int preemptible
+
+	File config_json
+	String output_dir
+	String genome
+
+	command {
+		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log
+
+		python <<CODE
+		from subprocess import check_call
+
+		call_args = ['cellranger-atac', 'mkref', '${genome}', '--config', '${config_json}']
+
+		print(' '.join(call_args))
+		check_call(call_args)
+
+		CODE
+
+		# gsutil -q cp -r ${genome} ${output_dir}/${genome}
+		mkdir -p ${output_dir}
+		cp -r ${genome} ${output_dir}/
+	}
+
+	output {
+		String output_folder = "${output_dir}/${genome}"
+	}
+
+	runtime {
+		docker: "${docker_registry}cellranger-atac:${cellranger_atac_version}"
+		zones: zones
+		memory: memory
+		bootDiskSizeGb: 12
+		disks: "local-disk ${disk_space} HDD"
+		cpu: 1
+		preemptible: "${preemptible}"
+	}
+}

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -42,15 +42,7 @@ task run_cellranger_atac_create_reference {
 		export TMPDIR=/tmp
 		monitor_script.sh > monitoring.log
 
-		python <<CODE
-		from subprocess import check_call
-
-		call_args = ['cellranger-atac', 'mkref', '${genome}', '--config', '${config_json}']
-
-		print(' '.join(call_args))
-		check_call(call_args)
-
-		CODE
+		cellranger-atac mkref ${genome} --config ${config_json}
 
 		# gsutil -q cp -r ${genome} ${output_dir}/${genome}
 		mkdir -p ${output_dir}

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -10,8 +10,6 @@ workflow cellranger_atac_create_reference {
 	String output_dir
 	String genome
 
-	Boolean do_filter = if '${attributes}' != '' then true else false
-
 	call run_cellranger_atac_create_reference as atac_mkref {
 		input:
 			docker_registry = docker_registry,

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -49,7 +49,7 @@ task run_cellranger_atac_create_reference {
 	}
 
 	output {
-		String output_folder = "${output_dir}/${genome}"
+		File reference = "${genome}.tar.gz"
 	}
 
 	runtime {

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -65,8 +65,6 @@ task run_cellranger_filter {
 
 	command {
 		set -e
-		export TMPDIR=/tmp
-		monitor_script.sh > monitoring.log
 
 		python <<CODE
 		from subprocess import check_call
@@ -114,8 +112,6 @@ task run_cellranger_create_reference {
 
 	command {
 		set -e
-		export TMPDIR=/tmp
-		monitor_script.sh > monitoring.log
 
 		python <<CODE
 		from subprocess import check_call
@@ -129,13 +125,14 @@ task run_cellranger_create_reference {
 		check_call(call_args)
 		CODE
 
-		# gsutil -q cp -r ${genome} ${output_dir}/${genome}
-		mkdir -p ${output_dir}
-		cp -r ${genome} ${output_dir}/
+		tar -czf ${genome}.tar.gz ${genome}
+		gsutil -q cp ${genome}.tar.gz ${output_dir}
+		# mkdir -p ${output_dir}
+		# cp ${genome}.tar.gz ${output_dir}
 	}
 
 	output {
-		String output_folder = "${output_dir}/${genome}"
+		String output_folder = "${output_dir}/${genome}.tar.gz"
 	}
 
 	runtime {

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -88,7 +88,6 @@ task run_cellranger_filter {
 		docker: "${docker_registry}cellranger:${cellranger_version}"
 		zones: zones
 		memory: "${memory}G"
-		bootDiskSizeGb: 12
 		disks: "local-disk ${disk_space} HDD"
 		cpu: 1
 		preemptible: "${preemptible}"
@@ -132,14 +131,13 @@ task run_cellranger_create_reference {
 	}
 
 	output {
-		String output_folder = "${output_dir}/${genome}.tar.gz"
+		File reference = "${output_dir}/${genome}.tar.gz"
 	}
 
 	runtime {
 		docker: "${docker_registry}cellranger:${cellranger_version}"
 		zones: zones
 		memory: "${memory}G"
-		bootDiskSizeGb: 12
 		disks: "local-disk ${disk_space} HDD"
 		cpu: "${num_cpu}"
 		preemptible: "${preemptible}"

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -5,7 +5,7 @@ workflow cellranger_create_reference {
 	Int? preemptible = 2
 	String? zones = "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c"
 	Int? num_cpu = 1
-	Int? memory = 16
+	Int? memory = 32
 
 	File input_gtf_file
 	String output_dir
@@ -75,7 +75,7 @@ task run_cellranger_filter {
 
 		call_args = ['cellranger', 'mkgtf', '${input_gtf_file}', '${genome}.filter.gtf']
 		for attr in attrs:
-			call_args.append('--attributes=' + attr)
+			call_args.append('--attribute=' + attr)
 
 		print(' '.join(call_args))
 		check_all(call_args)

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -76,7 +76,7 @@ task run_cellranger_filter {
 			call_args.append('--attribute=' + attr)
 
 		print(' '.join(call_args))
-		check_all(call_args)
+		check_call(call_args)
 		CODE
 	}
 

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -1,0 +1,161 @@
+workflow cellranger_create_reference {
+	String docker_registry = "cumulusprod/"
+	String cellranger_version = '3.0.2'
+	Int disk_space = 500
+	Int preemptible = 2
+
+	String input_file
+	String output_dir
+	String genome_list
+	String fasta_list
+	String genes_list
+	String attributes
+
+	Boolean is_sample_sheet = sub(input_file, "^.+\\.csv$", "CSV") == "CSV"
+
+
+	if (is_sample_sheet)
+
+	if ('${attributes}' != '') {
+		call run_cellranger_filter as filter {
+			input:
+				docker_registry = docker_registry,
+				cellranger_version = cellranger_version,
+				disk_space = disk_space,
+				preemptible = preemptible,
+				input_gtf_file = intput_gtf_file,
+				attributes = attributes
+		}
+	}
+
+
+
+
+}
+
+task generate_species {
+	String docker_registry
+	String cellranger_version
+	String disk_space
+	String preemptible
+	String zones
+	String memory
+
+	String input_csv_file
+
+	command {
+		set -e
+		export TMPDIR=/tmp
+
+		python <<CODE
+
+		import pandas as pd
+		from subprocess import check_call
+
+		df = pd.read_csv('${input_csv_file}', header = 0, dtype=str, index_col=False)
+		for col in df.columns:
+			df[col] = df[col].str.strip()
+
+
+
+		CODE
+	}
+
+
+	runtime {
+		docker: "${docker_registry}cellranger:${cellranger_version}"
+		zones: zones
+		preemptible: "${preemptible}"
+	}
+}
+
+task run_cellranger_filter {
+	String docker_registry
+	String cellranger_version
+	Int disk_space
+	String zones
+	String memory
+	Int preemptible
+
+	String input_gtf_file
+	String output_name
+	String attributes
+
+	command {
+		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log
+
+		python <<CODE
+		from subprocess import check_call
+
+		attrs = '${attributes}'.split(';')
+
+		call_args = ['cellranger', 'mkgtf', '${input_gtf_file}', '${output_name}.filter.gtf']
+		for attr in attrs:
+			call_args.append('--attributes=' + attr)
+
+		print(' '.join(call_args))
+		check_all(call_args)
+		CODE
+	}
+
+	output {
+		File output_gtf_file = '${output_name}.filter.gtf'
+	}
+
+	runtime {
+		docker: "${docker_registry}cellranger:${cellranger_version}"
+		zones: zones
+		memory: memory
+		bootDiskSizeGb: 12
+		disks: "local-disk ${disk_space} HDD"
+		cpu: 1
+		preemptible: "${preemptible}"
+	}
+}
+
+task run_cellranger_create_reference {
+	String docker_registry
+	String cellranger_version
+	Int disk_space
+	Int num_cpu
+	String zones
+	String memory
+	Int preemptible
+
+	String genome_list
+	String fasta_list
+	String genes_list
+	String? ref_version
+
+	command {
+		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log
+
+		python <<CODE
+		from subprocess import check_call
+
+		call_args = ['cellranger', 'mkref']
+
+		if '${ref_version}' is not '':
+			call_args.append('--ref-version=${ref_version}')
+
+		CODE
+	}
+
+	output {
+
+	}
+
+	runtime {
+		docker: "${docker_registry}cellranger:${cellranger_version}"
+		zones: zones
+		memory: memory
+		bootDiskSizeGb: 12
+		disks: "local-disk ${disk_space} HDD"
+		cpu: "${num_cpu}"
+		preemptible: "${preemptible}"
+	}
+}

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -125,6 +125,8 @@ task run_cellranger_create_reference {
 		if '${ref_version}' is not '':
 			call_args.append('--ref-version=${ref_version}')
 
+		print(' '.join(call_args))
+		check_call(call_args)
 		CODE
 
 		# gsutil -q cp -r ${genome} ${output_dir}/${genome}

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -65,6 +65,8 @@ task run_cellranger_filter {
 
 	command {
 		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log &
 
 		python <<CODE
 		from subprocess import check_call
@@ -111,6 +113,8 @@ task run_cellranger_create_reference {
 
 	command {
 		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log &
 
 		python <<CODE
 		from subprocess import check_call

--- a/workflows/smartseq2/smartseq2_create_reference.wdl
+++ b/workflows/smartseq2/smartseq2_create_reference.wdl
@@ -43,6 +43,8 @@ task rsem_prepare_reference {
 
 	command {
 		set -e
+		export TMPDIR=/tmp
+		monitor_script.sh > monitoring.log &
 
 		mkdir ${genome}
 		rsem-prepare-reference --gtf ${gtf} --bowtie2 -p ${cpu} ${fasta} ${genome}/${genome}

--- a/workflows/smartseq2/smartseq2_create_reference.wdl
+++ b/workflows/smartseq2/smartseq2_create_reference.wdl
@@ -1,6 +1,8 @@
 workflow smartseq2_create_reference {
 	File fasta
 	File gtf
+	String output_dir
+	String genome
 	String? smartseq2_version = "1.0.0"
 	String? zones = "us-central1-b"
 	Int? cpu = 8
@@ -14,6 +16,8 @@ workflow smartseq2_create_reference {
 		input:
 			fasta=fasta,
 			gtf=gtf,
+			output_dir = output_dir,
+			genome = genome,
 			smartseq2_version=smartseq2_version,
 			zones=zones,
 			preemptible=preemptible,
@@ -27,6 +31,8 @@ workflow smartseq2_create_reference {
 task rsem_prepare_reference {
 	File fasta
     File gtf
+    String output_dir
+    String genome
 	String smartseq2_version
 	String zones
 	Int preemptible
@@ -38,13 +44,17 @@ task rsem_prepare_reference {
 	command {
 		set -e
 
-		mkdir rsem_ref
-		rsem-prepare-reference --gtf ${gtf} --bowtie2 -p ${cpu} ${fasta} rsem_ref/rsem_ref
-		tar -czf rsem_ref.tar.gz rsem_ref
+		mkdir ${genome}
+		rsem-prepare-reference --gtf ${gtf} --bowtie2 -p ${cpu} ${fasta} ${genome}/${genome}
+		tar -czf ${genome}.tar.gz ${genome}
+
+		gsutil -q cp ${genome}.tar.gz ${output_dir}
+		# mkdir -p ${output_dir}
+		# cp ${genome}.tar.gz ${output_dir}
 	}
 
 	output {
-		File reference = "rsem_ref.tar.gz"
+		File reference = "${output_dir}/${genome}.tar.gz"
 	}
 
 	runtime {


### PR DESCRIPTION
Create cellranger_create_reference.wdl and cellranger_atac_create_reference.wdl. 

Modify smartseq2_create_reference.wdl to add output_dir and genome fields, so that results are saved after exiting Cromwell.