### PR TITLE
Integrate Optimus 2.0.0 into count WDL

### DIFF
--- a/docs/count.rst
+++ b/docs/count.rst
@@ -190,16 +190,11 @@ Below are inputs for *count* workflow. Notice that required inputs are in bold.
 	    | This input only works when setting *count_tool* to ``Bustools``.
 	  - "0.24.4"
 	  - "0.24.4"
-	* - optimus_version
-	  - | Optimus version to use. Currently only support 1.4.0.
-	    | This input only works when setting *count_tool* to ``Bustools``.
-	  - "optimus_v1.4.0"
-	  - "optimus_v1.4.0"
 	* - optimus_output_loom
 	  - | If Optimus generates gene-count matrices in ``loom`` format.
 	    | This input only works when setting *count_tool* to ``Optimus``.
-	  - false
-	  - false
+	  - true
+	  - true
 
 
 Workflow outputs

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -18,7 +18,7 @@ Latest version
 	  - `8 <https://portal.firecloud.org/?return=terra#methods/cumulus/cellranger_workflow/8>`_
 	  - Run Cell Ranger tools, which include extracting sequence reads using cellranger mkfastq or cellranger-atac mkfastq, generate count matrix using cellranger count or cellranger-atac count, run cellranger vdj or feature-barcode extraction
 	* - cumulus/count
-	  - `12 <https://portal.firecloud.org/?return=terra#methods/cumulus/count/12>`_
+	  - `13 <https://portal.firecloud.org/?return=terra#methods/cumulus/count/13>`_
 	  - Run alternative tools (STARsolo, Optimus, Salmon alevin, or Kallisto BUStools) to generate gene-count matrices from FASTQ files.
 	* - cumulus/cellranger_create_reference
 	  - `6 <https://portal.firecloud.org/?return=terra#methods/cumulus/cellranger_create_reference/6>`_

--- a/workflows/count_tools/count.wdl
+++ b/workflows/count_tools/count.wdl
@@ -4,7 +4,7 @@ import "https://api.firecloud.org/ga4gh/v1/tools/cumulus:count_tools_merge_fastq
 import "https://api.firecloud.org/ga4gh/v1/tools/cumulus:count_tools_starsolo/versions/10/plain-WDL/descriptor" as sts
 import "https://api.firecloud.org/ga4gh/v1/tools/cumulus:count_tools_bustools/versions/4/plain-WDL/descriptor" as kbc
 import "https://api.firecloud.org/ga4gh/v1/tools/cumulus:count_tools_alevin/versions/2/plain-WDL/descriptor" as ale
-import "https://api.firecloud.org/ga4gh/v1/tools/cumulus:count_tools_optimus/versions/6/plain-WDL/descriptor" as opm
+import "https://api.firecloud.org/ga4gh/v1/tools/cumulus:count_tools_optimus/versions/7/plain-WDL/descriptor" as opm
 
 #import "merge_fastqs.wdl" as mfs
 #import "star-solo.wdl" as sts
@@ -47,8 +47,7 @@ workflow count {
         String bustools_version = '0.24.4'
 
         # Optimus
-        String optimus_version = 'optimus_v1.4.0'
-        Boolean optimus_output_loom = false
+        Boolean optimus_output_loom = true
     }
 
     call generate_count_config as Config {
@@ -155,7 +154,6 @@ workflow count {
                         output_directory = output_directory,
                         output_loom = optimus_output_loom,
                         docker_registry = docker_registry,
-                        version = optimus_version,
                         disk_space = disk_space,
                         preemptible = preemptible,
                         cpu_for_copy = num_cpu,

--- a/workflows/count_tools/optimus-count.wdl
+++ b/workflows/count_tools/optimus-count.wdl
@@ -138,7 +138,12 @@ task organize_result {
         mkdir output/zarr_output
         cp ~{sep=" " zarr_files} output/zarr_output
 
-        cp ~{loom_file} output
+        python <<CODE
+        from subprocess import check_call
+
+        if '~{loom_file}' is not '':
+            check_call(['cp', '~{loom_file}', 'output'])
+        CODE
 
         gsutil -q -m rsync -r output ~{output_directory}/~{sample_id}
         # mkdir -p ~{output_directory}/~{sample_id}

--- a/workflows/count_tools/optimus-count.wdl
+++ b/workflows/count_tools/optimus-count.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/lilab-bcb/skylab/cumulus/pipelines/optimus/Optimus.wdl" as opm
+import "https://raw.githubusercontent.com/HumanCellAtlas/skylab/optimus_v2.0.0_terra/pipelines/optimus/Optimus.wdl" as opm
 # import "../../../skylab/pipelines/optimus/Optimus.wdl" as opm
 
 workflow optimus_count {
@@ -15,7 +15,7 @@ workflow optimus_count {
         Boolean output_loom
 
         String docker_registry = "cumulusprod"
-        String version = 'optimus_v1.4.0'
+        String version = 'optimus_v2.0.0'
         Int cpu_for_copy = 32
         Int disk_space = 100
         Int preemptible = 2


### PR DESCRIPTION
* Update count_tools_optimus WDL with Optimus 2.0.0;
* In count WDL, remove ``optimus_version`` input, set ``optimus_output_loom`` default to ``true``;
* Fix bug in count_tools_optimus WDL when ``output_loom`` is false.