### PR TITLE
Make count WDL use Quay images and config docker

### DIFF
--- a/docs/count.rst
+++ b/docs/count.rst
@@ -132,6 +132,10 @@ Below are inputs for *count* workflow. Notice that required inputs are in bold.
 	  	- "cumulusprod" for backup images on Docker Hub.
 	  - "quay.io/cumulus"
 	  - "quay.io/cumulus"
+	* - config_version
+	  - Version of config docker image to use. This docker is used for parsing the input sample sheet for downstream execution. Currently only one version is available: ``0.1``.
+	  - "0.1"
+	  - "0.1"
 	* - zones
 	  - Google cloud zones to consider for execution.
 	  - "us-east1-d us-west1-a us-west1-b"

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -21,7 +21,7 @@ Latest version
       - `3 <https://portal.firecloud.org/?return=terra#methods/cumulus/star_solo/3>`_
       - Run STARsolo to generate gene-count matrices fro FASTQ files.
     * - cumulus/count
-      - `16 <https://portal.firecloud.org/?return=terra#methods/cumulus/count/16>`__
+      - `17 <https://portal.firecloud.org/?return=terra#methods/cumulus/count/16>`__
       - Run alternative tools (STARsolo, Optimus, Salmon alevin, or Kallisto BUStools) to generate gene-count matrices from FASTQ files.
     * - cumulus/demultiplexing
       - `21 <https://portal.firecloud.org/?return=terra#methods/cumulus/demultiplexing/21>`_

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -21,7 +21,7 @@ Latest version
       - `3 <https://portal.firecloud.org/?return=terra#methods/cumulus/star_solo/3>`_
       - Run STARsolo to generate gene-count matrices fro FASTQ files.
     * - cumulus/count
-      - `17 <https://portal.firecloud.org/?return=terra#methods/cumulus/count/16>`__
+      - `17 <https://portal.firecloud.org/?return=terra#methods/cumulus/count/17>`__
       - Run alternative tools (STARsolo, Optimus, Salmon alevin, or Kallisto BUStools) to generate gene-count matrices from FASTQ files.
     * - cumulus/demultiplexing
       - `21 <https://portal.firecloud.org/?return=terra#methods/cumulus/demultiplexing/21>`_

--- a/workflows/count_tools/count.wdl
+++ b/workflows/count_tools/count.wdl
@@ -24,7 +24,8 @@ workflow count {
         Boolean run_count = true
         String count_tool = "StarSolo"
 
-        String docker_registry = "cumulusprod"
+        String docker_registry = "quay.io/cumulus"
+        String config_version = "0.1"
         Int num_cpu = 32
         Int disk_space = 500
         Int memory = 120
@@ -54,6 +55,7 @@ workflow count {
         input:
             input_tsv_file = input_tsv_file,
             docker_registry = docker_registry,
+            config_version = config_version,
             zones = zones,
             preemptible = preemptible
     }
@@ -175,6 +177,7 @@ task generate_count_config {
     input {
         File input_tsv_file
         String docker_registry
+        String config_version
         String zones
         Int preemptible
     }
@@ -247,7 +250,7 @@ task generate_count_config {
     }
 
     runtime {
-        docker: "~{docker_registry}/count"
+        docker: "~{docker_registry}/config:~{config_version}"
         zones: zones
         preemptible: "~{preemptible}"
     }


### PR DESCRIPTION
In `count_tools/count.wdl`:
* Use `quay.io/cumulus` registry by default.
* Use `config` docker image for configuration task, so that `count` docker image can be removed.