### PR TITLE
Adjust for AWS backend & SpaceRanger bug fix

### DIFF
--- a/docs/spaceranger.rst
+++ b/docs/spaceranger.rst
@@ -109,7 +109,7 @@ Alternatively, users can submit jobs through command line interface (CLI) using 
 		* - SlideFile
 		  - Slide layout file indicating capture spot and fiducial spot positions. Only required if internet access is not available.
 		* - ReorientImages
-		  - Use with automatic image alignment to specify that images may not be in canonical orientation with the hourglass in the top left corner of the image. The automatic fiducial alignment will attempt to align any rotation or mirroring of the image.
+		  - **Valid values**: ``true`` or ``false``. Use with automatic image alignment to specify that images may not be in canonical orientation with the hourglass in the top left corner of the image. The automatic fiducial alignment will attempt to align any rotation or mirroring of the image.
 		* - LoupeAlignment
 		  - Alignment file produced by the manual Loupe alignment step. Image column must be supplied in this case.
 		* - TargetPanel

--- a/workflows/spaceranger/spaceranger_count.wdl
+++ b/workflows/spaceranger/spaceranger_count.wdl
@@ -223,7 +223,7 @@ task run_spaceranger_count {
                 call_args.append('--slidefile=~{slidefile}')
 
         if '~{reorient_images}' is 'true':
-            call_args.append('--reorient_images')
+            call_args.append('--reorient-images')
         if not_null('~{loupe_alignment}'):
             if not has_image:
                 print("image option must be set if loupe_alignment is set!", file = sys.stderr)

--- a/workflows/spaceranger/spaceranger_count.wdl
+++ b/workflows/spaceranger/spaceranger_count.wdl
@@ -16,8 +16,6 @@ workflow spaceranger_count {
 
         # Referece index TSV
         File acronym_file
-        # An empty full representing null
-        File null_file
 
         # Brightfield tissue H&E image in .jpg or .tiff format.
         File? image
@@ -68,6 +66,7 @@ workflow spaceranger_count {
     }
 
     Map[String, String] acronym2url = read_map(acronym_file)
+    File null_file = acronym2url["null_file"]
 
     # If reference is a url
     Boolean is_url = sub(genome, "^.+\\.(tgz|gz)$", "URL") == "URL"

--- a/workflows/spaceranger/spaceranger_workflow.wdl
+++ b/workflows/spaceranger/spaceranger_workflow.wdl
@@ -24,8 +24,6 @@ workflow spaceranger_workflow {
 
         # Referece index TSV
         File acronym_file = "gs://regev-lab/resources/cellranger/index.tsv"
-        # null_file
-        String null_file = "gs://regev-lab/resources/cellranger/null"
 
         # For spaceranger count
 
@@ -68,6 +66,9 @@ workflow spaceranger_workflow {
 
     String docker_registry_stripped = sub(docker_registry, "/+$", "")
     String mkfastq_docker_registry_stripped = sub(mkfastq_docker_registry, "/+$", "")
+
+    Map[String, String] acronym2gsurl = read_map(acronym_file)
+    String null_file = acronym2gsurl["null_file"]
 
     if (run_mkfastq) {
         call generate_bcl_csv {
@@ -128,7 +129,6 @@ workflow spaceranger_workflow {
                     genome = sample_row[2],
                     probeset = sample_row[3],
                     acronym_file = acronym_file,
-                    null_file = null_file,
                     image = sample_row[4],
                     darkimagestr = sample_row[5],
                     colorizedimage = sample_row[6],

--- a/workflows/star_solo/star-solo.wdl
+++ b/workflows/star_solo/star-solo.wdl
@@ -26,6 +26,8 @@ workflow starsolo {
         String star_version = "2.7.6a"
         # Docker registry, default to quay.io/cumulus
         String docker_registry = "quay.io/cumulus"
+        File ref_index_file = "gs://regev-lab/resources/count_tools/ref_index.tsv"
+        File whitelist_index_file = "gs://regev-lab/resources/count_tools/whitelist_index.tsv"
         # Disk space in GB needed per sample
         Int disk_space = 500
         # Google cloud zones to consider for execution
@@ -43,13 +45,11 @@ workflow starsolo {
     # Output directory, with trailing slashes stripped
     String output_directory_stripped = sub(output_directory, "[/\\s]+$", "")
 
-    File ref_index_file = if backend == "gcp" then "gs://regev-lab/resources/count_tools/ref_index.tsv" else (if backend == "aws" then "AWS URL" else "ref_index.tsv")
-    Map[String, String] ref_index2gsurl = read_map(ref_index_file)
-    String genome_url = if sub(genome, "^gs://.*", "gs://")=="gs://" then genome else ref_index2gsurl[genome] + '/starsolo.tar.gz' # Need to modify for AWS etc.
+    Map[String, String] ref_index2url = read_map(ref_index_file)
+    String genome_url = if sub(genome, "^(gs|s3)://.*", "URL")=="URL" then genome else ref_index2url[genome] + '/starsolo.tar.gz'
 
-    File wl_index_file = if backend == "gcp" then "gs://regev-lab/resources/count_tools/whitelist_index.tsv" else (if backend == "aws" then "AWS URL" else "whitelist_index.tsv")
-    Map[String, String] wl_index2gsurl = read_map(wl_index_file)
-    String whitelist_url = wl_index2gsurl[chemistry]
+    Map[String, String] wl_index2url = read_map(whitelist_index_file)
+    String whitelist_url = wl_index2url[chemistry]
 
     if (whitelist_url != 'null') {
         File whitelist = whitelist_url

--- a/workflows/star_solo/star-solo.wdl
+++ b/workflows/star_solo/star-solo.wdl
@@ -26,7 +26,9 @@ workflow starsolo {
         String star_version = "2.7.6a"
         # Docker registry, default to quay.io/cumulus
         String docker_registry = "quay.io/cumulus"
+        # Reference Index TSV
         File ref_index_file = "gs://regev-lab/resources/count_tools/ref_index.tsv"
+        # Whitelist Index TSV
         File whitelist_index_file = "gs://regev-lab/resources/count_tools/whitelist_index.tsv"
         # Disk space in GB needed per sample
         Int disk_space = 500


### PR DESCRIPTION
In `star-solo.wdl`: 
* Expose `ref_index_file` and `whitelist_index_file` as workflow inputs.
* Accept custom genome reference from both GS and S3 URI.

In `spaceranger_workflow.wdl`:
* Remove `null_file` input, because its index is already in `acronym_file` file.

In `spaceranger_count.wdl`:
* Fix bug on `reorient_image` input.