### PR TITLE
Adjust starsolo_count for SHARE-Seq data

### DIFF
--- a/docs/starsolo.rst
+++ b/docs/starsolo.rst
@@ -126,6 +126,12 @@ Below are inputs for *count* workflow. Notice that required inputs are in bold.
         | If fastq files are not zipped, substitute ``.fastq`` for ``.fastq.gz`` in the corresponding pattern above.
       - "_S*_L*_R2_001.fastq.gz"
       - "_S*_L*_R2_001.fastq.gz"
+    * - barcode_read
+      - | Specify which read contains cell barcodes and UMIs: either ``read1`` or ``read2``. This only applies to samples with *Assay* ``None`` in the *input_csv_file*.
+        | Otherwise, samples with *Assay* type ``ShareSeq`` automatically specify ``read2`` for cell barcodes and UMIs, while ``read1`` for cDNAs;
+        | samples of all the other know *Assay* types automatically specify ``read1`` for cell barcodes and UMIs, while ``read2`` for cDNAs.
+      - "read1"
+      - "read1"
     * - soloType
       - [STARsolo option] Type of single-cell RNA-seq, choosing from *CB_UMI_Simple*, *CB_UMI_Complex*, *CB_samTagOut*, *SmartSeq*.
       - "CB_UMI_Simple"

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -10,6 +10,8 @@ workflow starsolo_workflow {
         String output_directory
         String read1_fastq_pattern = "_S*_L*_R1_001.fastq.gz"
         String read2_fastq_pattern = "_S*_L*_R2_001.fastq.gz"
+        # Which read contains cell barcodes and UMIs. Either "read1" or "read2"
+        String barcode_read = "read1"
         # Type of SAM/BAM output
         String? outSAMtype
         # Type of single-cell RNA-seq
@@ -107,6 +109,7 @@ workflow starsolo_workflow {
                     acronym_file = acronym_file,
                     read1_fastq_pattern = read1_fastq_pattern,
                     read2_fastq_pattern = read2_fastq_pattern,
+                    barcode_read = barcode_read,
                     outSAMtype = outSAMtype,
                     soloType = soloType,
                     soloCBstart = soloCBstart,


### PR DESCRIPTION
Add `barcode_read` input to allow user specify which read (read1 or read2) contains cell barcodes and UMIs.