### PR TITLE
Add 10x 5p protocol support to STARsolo WDL workflow

### DIFF
--- a/docker/starsolo/2.7.10a/Dockerfile
+++ b/docker/starsolo/2.7.10a/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:bullseye-slim
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get -qq update && \
+    apt-get -qq -y install --no-install-recommends \
+        wget \
+        build-essential \
+        curl \
+        unzip \
+        gnupg \
+        python3 \
+        python3-pip
+
+RUN pip3 install --upgrade pip --no-cache-dir && \
+    pip3 install numpy==1.21.5 --no-cache-dir && \
+    pip3 install pandas==1.3.5 --no-cache-dir && \
+    pip3 install stratocumulus==0.1.3 --no-cache-dir
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+    apt-get update -y && apt-get install -y google-cloud-sdk=370.0.0-0
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.13.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip
+
+RUN wget https://github.com/alexdobin/STAR/archive/refs/tags/2.7.10a.tar.gz && \
+    tar -xzvf 2.7.10a.tar.gz && \
+    rm 2.7.10a.tar.gz && \
+    mkdir /software && \
+    mv STAR-2.7.10a/ /software/STAR
+
+RUN apt-get -qq -y remove curl gnupg wget curl && \
+    apt-get -qq -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/log/dpkg.log && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
+ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+RUN chmod a+rx /software/monitor_script.sh
+
+ENV PATH=/software:/software/STAR/bin/Linux_x86_64:$PATH

--- a/docs/starsolo.rst
+++ b/docs/starsolo.rst
@@ -51,25 +51,28 @@ A brief description of the sample sheet format is listed below **(required colum
       - Indicates the Cloud bucket URI of the folder holding FASTQ files of each sample.
     * - Assay
       - | Indicates the assay type of each sample.
-        | Available options: ``tenX_v3`` for 10X v3, ``tenX_v2`` for 10X v2, ``DropSeq``, ``SeqWell``, ``SlideSeq``, ``ShareSeq`` and ``None``.
+        | Available options: ``tenX_v3`` for 10X v3, ``tenX_v2`` for 10X v2, ``tenX_fiveprime`` for 10X 5' protocol, ``DropSeq``, ``SeqWell``, ``SlideSeq``, ``ShareSeq`` and ``None``.
         | If not specified, use the default ``tenX_v3``.
-        | If ``tenX_v3``, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 16 --soloUMIstart 17 --soloUMIlen 12 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
+        | If **tenX_v3**, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 16 --soloUMIstart 17 --soloUMIlen 12 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
         | ``--soloUMIdedup 1MM_CR --clipAdapterType CellRanger4 --outFilterScoreMin 30 --outSAMtype BAM SortedByCoordinate --outSAMattributes CR UR CY UY CB UB``
-        | If ``tenX_v2``, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 16 --soloUMIstart 17 --soloUMIlen 10 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
+        | If **tenX_v2**, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 16 --soloUMIstart 17 --soloUMIlen 10 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
         | ``--soloUMIdedup 1MM_CR --clipAdapterType CellRanger4 --outFilterScoreMin 30 --outSAMtype BAM SortedByCoordinate --outSAMattributes CR UR CY UY CB UB``
-        | If ``ShareSeq``, the following STARsolo options would be applied (could be overwritten by user-specific options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 24 --soloUMIstart 25 --soloUMIlen 10 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
+        | If **tenX_fiveprime**, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 16 --soloUMIstart 17 --soloUMIlen 10 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
+        | ``--soloBarcodeMate 1 --clip5pNbases 39 0 --soloUMIdedup 1MM_CR --outFilterScoreMin 30 --outSAMtype BAM SortedByCoordinate --outSAMattributes CR UR CY UY CB UB``
+        | Moreover, for **tenX_fiveprime** assays, if Read 1 has more than 39 nt, ``--soloStrand Reverse`` option will be used.
+        | If **ShareSeq**, the following STARsolo options would be applied (could be overwritten by user-specific options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 24 --soloUMIstart 25 --soloUMIlen 10 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR``
         | ``--soloUMIdedup 1MM_CR --clipAdapterType CellRanger4 --outFilterScoreMin 30 --outSAMtype BAM SortedByCoordinate --outSAMattributes CR UR CY UY CB UB``
-        | If ``SeqWell`` or ``DropSeq``, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 12 --soloUMIstart 13 --soloUMIlen 8 --outSAMtype BAM SortedByCoordinate --outSAMattributes CR UR CY UY CB UB``
-        | If ``None``, not preset options would be applied.
+        | If **SeqWell** or **DropSeq**, the following STARsolo options would be applied (could be overwritten by user-specified options): ``--soloType CB_UMI_Simple --soloCBstart 1 --soloCBlen 12 --soloUMIstart 13 --soloUMIlen 8 --outSAMtype BAM SortedByCoordinate --outSAMattributes CR UR CY UY CB UB``
+        | If **None**, no preset option would be applied.
 
 The sample sheet supports sequencing the same sample across multiple flowcells. In case of multiple flowcells, you should specify one line for each flowcell using the same sample name. In the following example, we have 2 samples and ``sample_1`` is sequenced in two flowcells.
 
 Example::
 
-    Sample,Location
-    sample_1,gs://fc-e0000000-0000-0000-0000-000000000000/VK18WBC6Z4/sample_1_fastqs
-    sample_1,gs://fc-e0000000-0000-0000-0000-000000000000/VK10WBC9Z2/sample_1_fastqs
-    sample_2,gs://fc-e0000000-0000-0000-0000-000000000000/VK18WBC6Z4/sample_2_fastqs
+    Sample,Reference,Location,Assay
+    sample_1,GRCh38-2020-A,gs://fc-e0000000-0000-0000-0000-000000000000/VK18WBC6Z4/sample_1_fastqs,tenX_v3
+    sample_1,GRCh38-2020-A,gs://fc-e0000000-0000-0000-0000-000000000000/VK10WBC9Z2/sample_1_fastqs,tenX_v3
+    sample_2,GRCh38-2020-A,gs://fc-e0000000-0000-0000-0000-000000000000/VK18WBC6Z4/sample_2_fastqs,tenX_v2
 
 
 **3.2 Upload your sample sheet to the workspace bucket:**

--- a/workflows/starsolo/index.tsv
+++ b/workflows/starsolo/index.tsv
@@ -4,9 +4,9 @@ GRCh38	gs://regev-lab/resources/starsolo/GRCh38-starsolo.tar.gz
 mm10	gs://regev-lab/resources/starsolo/mm10-starsolo.tar.gz
 GRCh38-2020-A-premrna	gs://regev-lab/resources/starsolo/GRCh38-2020-A-premrna-starsolo.tar.gz
 mm10-2020-A-premrna	gs://regev-lab/resources/starsolo/mm10-2020-A-premrna-starsolo.tar.gz
-tenX_v3	gs://regev-lab/resources/count_tools/3M-february-2018.txt
-tenX_v2	gs://regev-lab/resources/count_tools/737K-august-2016.txt
-tenX_fiveprime	gs://regev-lab/resources/count_tools/737K-august-2016.txt
+tenX_v3	gs://regev-lab/resources/starsolo/3M-february-2018.txt
+tenX_v2	gs://regev-lab/resources/starsolo/737K-august-2016.txt
+tenX_fiveprime	gs://regev-lab/resources/starsolo/737K-august-2016.txt
 DropSeq	null
 SeqWell	null
 SlideSeq	null

--- a/workflows/starsolo/index.tsv
+++ b/workflows/starsolo/index.tsv
@@ -6,6 +6,7 @@ GRCh38-2020-A-premrna	gs://regev-lab/resources/starsolo/GRCh38-2020-A-premrna-st
 mm10-2020-A-premrna	gs://regev-lab/resources/starsolo/mm10-2020-A-premrna-starsolo.tar.gz
 tenX_v3	gs://regev-lab/resources/count_tools/3M-february-2018.txt
 tenX_v2	gs://regev-lab/resources/count_tools/737K-august-2016.txt
+tenX_fiveprime	gs://regev-lab/resources/count_tools/737K-august-2016.txt
 DropSeq	null
 SeqWell	null
 SlideSeq	null

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -243,9 +243,17 @@ task run_starsolo {
                     args_dict['--clipAdapterType'] = 'CellRanger4'
                     barcode_read = 'read1'
                 else:
-                    args_dict['--soloBarcodeMate'] = '2'
+                    args_dict['--soloBarcodeMate'] = '1'
                     args_dict['--clip5pNbases'] = ['39', '0']
-                    barcode_read = 'read1'
+                    barcode_read = 'read2'
+                    import gzip
+                    with gzip.open(r1_list[0], 'rb') as fin:
+                        cnt = 0
+                        while cnt < 2:
+                            r1_read_str = fin.readline().strip()
+                            cnt += 1
+                    if len(r1_read_str) > 39:
+                        args_dict['--soloStrand'] = 'Reverse'
             elif '~{assay}' == 'ShareSeq':
                 args_dict['--soloCBstart'] = '1'
                 args_dict['--soloCBlen'] = '24'

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -98,7 +98,7 @@ workflow starsolo_count {
 
     output {
         File monitoringLog = run_starsolo.monitoringLog
-        String output_folder = run_starsolo.output_folder
+        String output_count_directory = run_starsolo.output_count_directory
     }
 }
 
@@ -353,7 +353,7 @@ task run_starsolo {
 
     output {
         File monitoringLog = 'monitoring.log'
-        String output_folder = '~{output_directory}/~{sample_id}'
+        String output_count_directory = '~{output_directory}/~{sample_id}'
     }
 
     runtime {

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -245,7 +245,6 @@ task run_starsolo {
                 else:
                     args_dict['--soloBarcodeMate'] = '1'
                     args_dict['--clip5pNbases'] = ['39', '0']
-                    args_dict['--clipAdapterType'] = 'CellRanger4'
                     args_dict['--soloStrand'] = 'Reverse'
                     barcode_read = 'read2'
             elif '~{assay}' == 'ShareSeq':

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -217,12 +217,11 @@ task run_starsolo {
         barcode_read = '~{barcode_read}'
         args_dict = dict()
 
-        if '~{assay}' in ['tenX_v2', 'tenX_v3', 'ShareSeq']:
+        if '~{assay}' in ['tenX_v2', 'tenX_v3', 'ShareSeq', 'tenX_fiveprime']:
             args_dict['--soloType'] = 'CB_UMI_Simple'
             args_dict['--soloCBmatchWLtype'] = '1MM_multi_Nbase_pseudocounts'
             args_dict['--soloUMIfiltering'] = 'MultiGeneUMI_CR'
             args_dict['--soloUMIdedup'] = '1MM_CR'
-            args_dict['--clipAdapterType'] = 'CellRanger4'
             args_dict['--outFilterScoreMin'] = '30'
             args_dict['--outSAMtype'] = ['BAM', 'SortedByCoordinate']
             args_dict['--outSAMattributes'] = ['CR', 'UR', 'CY', 'UY', 'CB', 'UB']
@@ -232,13 +231,24 @@ task run_starsolo {
                 args_dict['--soloCBlen'] = '16'
                 args_dict['--soloUMIstart'] = '17'
                 args_dict['--soloUMIlen'] = '12'
+                args_dict['--clipAdapterType'] = 'CellRanger4'
                 barcode_read = 'read1'
-            elif '~{assay}' == 'tenX_v2':
+            elif '~{assay}' in ['tenX_v2', 'tenX_fiveprime']:
                 args_dict['--soloCBstart'] = '1'
                 args_dict['--soloCBlen'] = '16'
                 args_dict['--soloUMIstart'] = '17'
                 args_dict['--soloUMIlen'] = '10'
-                barcode_read = 'read1'
+
+                if '~{assay}' == 'tenX_v2':
+                    args_dict['--clipAdapterType'] = 'CellRanger4'
+                    barcode_read = 'read1'
+                else:
+                    args_dict['--soloBarcodeMate'] = '1'
+                    args_dict['--clip5pNbases'] = ['39', '0']
+                    args_dict['--soloStrand'] = 'Reverse'
+                    args_dict['--soloCellFilter'] = 'EmptyDrops_CR'                       ## not sure if required
+                    args_dict['--soloFeatures'] = ['Gene', 'GeneFull', 'SJ', 'Velocyto']  ## not sure if required
+                    barcode_read = 'read2'
             elif '~{assay}' == 'ShareSeq':
                 args_dict['--soloCBstart'] = '1'
                 args_dict['--soloCBlen'] = '24'

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -243,10 +243,9 @@ task run_starsolo {
                     args_dict['--clipAdapterType'] = 'CellRanger4'
                     barcode_read = 'read1'
                 else:
-                    args_dict['--soloBarcodeMate'] = '1'
+                    args_dict['--soloBarcodeMate'] = '2'
                     args_dict['--clip5pNbases'] = ['39', '0']
-                    args_dict['--soloStrand'] = 'Reverse'
-                    barcode_read = 'read2'
+                    barcode_read = 'read1'
             elif '~{assay}' == 'ShareSeq':
                 args_dict['--soloCBstart'] = '1'
                 args_dict['--soloCBlen'] = '24'

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -246,8 +246,6 @@ task run_starsolo {
                     args_dict['--soloBarcodeMate'] = '1'
                     args_dict['--clip5pNbases'] = ['39', '0']
                     args_dict['--soloStrand'] = 'Reverse'
-                    args_dict['--soloCellFilter'] = 'EmptyDrops_CR'                       ## not sure if required
-                    args_dict['--soloFeatures'] = ['Gene', 'GeneFull', 'SJ', 'Velocyto']  ## not sure if required
                     barcode_read = 'read2'
             elif '~{assay}' == 'ShareSeq':
                 args_dict['--soloCBstart'] = '1'

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -64,8 +64,8 @@ workflow starsolo_workflow {
         String? soloOutFormatFeaturesGeneField3
         # Number of CPUs to request per sample
         Int num_cpu = 32
-        # STAR version to use. Currently support: 2.7.9a
-        String star_version = "2.7.9a"
+        # STAR version to use. Currently support: 2.7.10a, 2.7.9a
+        String star_version = "2.7.10a"
         # Docker registry, default to quay.io/cumulus
         String docker_registry = "quay.io/cumulus"
         # Reference Index TSV

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -64,8 +64,8 @@ workflow starsolo_workflow {
         String? soloOutFormatFeaturesGeneField3
         # Number of CPUs to request per sample
         Int num_cpu = 32
-        # STAR version to use. Currently support: 2.7.10a, 2.7.9a
-        String star_version = "2.7.10a"
+        # STAR version to use. Currently support: 2.7.9a
+        String star_version = "2.7.9a"
         # Docker registry, default to quay.io/cumulus
         String docker_registry = "quay.io/cumulus"
         # Reference Index TSV


### PR DESCRIPTION
* Add `tenX_fiveprime` type for **Assay** field in the sample sheet.
* Preset STARsolo options for 10x 5' protocol, following the discussion in [this STAR issue](https://github.com/alexdobin/STAR/issues/768) and Section "[Barcode and cDNA on the same mate](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md#barcode-and-cdna-on-the-same-mate)" in STARsolo documentation.
  * Notice that if Read 1 has no more than 39 nt, we should not set `--soloStrand Reverse` option, because only Read 2 will be left after trimming, and it should be treated as single-end RNA-seq.
* Rename `output_folder` to `output_count_directory` in `starsolo_count.wdl`. 
* Update documentation.
* Add docker image for STAR v2.7.10a, but it's still under testing.