### PR TITLE
fix bug in memory specification

### DIFF
--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -242,7 +242,7 @@ task run_filter_gtf {
     runtime {
         docker: "~{docker_registry}/cellranger:~{cellranger_version}"
         zones: zones
-        memory: "~{memory}G"
+        memory: memory
         disks: "local-disk ~{disk_space} HDD"
         cpu: 1
         preemptible: preemptible


### PR DESCRIPTION
The `memory` input is required to use format like `"32G"`, but WDL task **run_filter_gtf** incorrectly wraps it as `"32GG"` to the runtime attribute list.